### PR TITLE
Improve verify request logging and throttle /health/live access logs

### DIFF
--- a/src/open_hallucination_index/infrastructure/entrypoint.py
+++ b/src/open_hallucination_index/infrastructure/entrypoint.py
@@ -27,10 +27,14 @@ def main() -> None:
         format="%(asctime)s | %(levelname)-8s | %(name)s | %(message)s",
         datefmt="%Y-%m-%d %H:%M:%S",
     )
+    from open_hallucination_index.infrastructure.logging import HealthLiveAccessFilter
 
     logger = logging.getLogger(__name__)
     logger.info(f"Starting {settings.api.title} v{settings.api.version}")
     logger.info(f"Environment: {settings.environment}")
+
+    access_logger = logging.getLogger("uvicorn.access")
+    access_logger.addFilter(HealthLiveAccessFilter(min_interval_seconds=120.0))
 
     # Determine host: use 127.0.0.1 for IPv4 when 0.0.0.0 is configured
     api_host = settings.api.host

--- a/src/open_hallucination_index/infrastructure/logging.py
+++ b/src/open_hallucination_index/infrastructure/logging.py
@@ -1,0 +1,29 @@
+"""
+Logging utilities for API runtime.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+
+
+class HealthLiveAccessFilter(logging.Filter):
+    """Throttle /health/live access log entries to reduce log noise."""
+
+    def __init__(self, min_interval_seconds: float = 120.0) -> None:
+        super().__init__()
+        self._min_interval_seconds = min_interval_seconds
+        self._last_logged: float | None = None
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        message = record.getMessage()
+        if "/health/live" not in message:
+            return True
+
+        now = time.monotonic()
+        if self._last_logged is None or (now - self._last_logged) >= self._min_interval_seconds:
+            self._last_logged = now
+            return True
+
+        return False


### PR DESCRIPTION
### Motivation
- Reduce noisy `/health/live` access log entries and show anonymized, immediate visibility when a verify request starts, completes, or fails.
- Avoid logging sensitive request payloads while surfacing actionable metadata for debugging (timings, request ids, strategy, cache usage).
- Make it easier to spot failing verifications in container logs without flooding them with frequent health checks.

### Description
- Add structured start/completion/failure logging to the `POST /verify` and `POST /verify/batch` handlers with a generated `request_id` and anonymized metadata like `text_length`, `strategy`, `use_cache`, timings and `cached` flag in `src/open_hallucination_index/api/routes/verification.py`.
- Introduce `HealthLiveAccessFilter` in `src/open_hallucination_index/infrastructure/logging.py` to throttle `/health/live` access log messages to at most once every 120 seconds.
- Register the access-log filter on the `uvicorn.access` logger during startup in `src/open_hallucination_index/infrastructure/entrypoint.py`.
- Avoid logging full request bodies by logging only lengths/flags and verification IDs for correlation.

### Testing
- No automated tests were run for these changes.
- The changes are limited to logging and startup wiring and do not modify core verification logic or API responses.
- Manual review of diffs was performed to ensure no sensitive text payloads are included in logs.
- Recommend running the service and exercising `/api/v1/verify` and `/health/live` to validate log output and throttling behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e2def0540832595996d9a003940f6)