### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -12,6 +12,9 @@ on:
       - 'frontend/**'
       - '.github/workflows/frontend.yml'
 
+permissions:
+  contents: read
+
 env:
   NODE_VERSION: "22"
 


### PR DESCRIPTION
Potential fix for [https://github.com/shiftbloom-studio/open-hallucination-index/security/code-scanning/7](https://github.com/shiftbloom-studio/open-hallucination-index/security/code-scanning/7)

Generally, to fix this type of issue you explicitly configure the `permissions` for the `GITHUB_TOKEN` at the workflow or job level, granting only the scopes needed (usually `contents: read` for basic CI). This avoids inheriting potentially over‑permissive repository defaults.

For this workflow, the simplest, least-disruptive fix is:

- Add a workflow-level `permissions:` block near the top (after `name:` or after `on:`).
- Set it to `contents: read`, which is sufficient for `actions/checkout` and all the npm-based steps in `lint`, `test`, `build`, and `e2e`.
- This automatically applies to all jobs since none of them define their own `permissions`.

Concretely, in `.github/workflows/frontend.yml`, insert:

```yaml
permissions:
  contents: read
```

after the `on:` block (line 14) or right after `name: Frontend CI`. No other code or imports are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
