### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/shiftbloom-studio/open-hallucination-index/security/code-scanning/6](https://github.com/shiftbloom-studio/open-hallucination-index/security/code-scanning/6)

General fix: Explicitly declare minimal required GITHUB_TOKEN permissions for jobs. Since `lint`, `test`, and `security` only read code and run local tools, they can safely run with `contents: read`. The `release` job already has a suitable `permissions` block (`contents: write`).

Best concrete fix: Add a root‑level `permissions` block just under the `name: CI` line, setting `contents: read`. This applies to all jobs that don’t define their own permissions (`lint`, `test`, `security`) and leaves the existing `release` job permissions untouched because job-level permissions override workflow-level ones. This change is minimal, localized, and does not alter any job behavior.

Specific changes in `.github/workflows/ci.yml`:
- Immediately after line 1 (`name: CI`), insert:
  ```yaml
  permissions:
    contents: read
  ```
- No other changes are required.

No imports or additional methods are needed, as this is purely a workflow configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
