### PR TITLE
Potential fix for code scanning alert no. 8: Exception text reinterpreted as HTML

### DIFF
--- a/frontend/src/app/api/webhooks/stripe/route.ts
+++ b/frontend/src/app/api/webhooks/stripe/route.ts
@@ -19,7 +19,8 @@ export async function POST(req: Request) {
       process.env.STRIPE_WEBHOOK_SECRET!
     );
   } catch (error) {
-    return new NextResponse(`Webhook Error: ${(error as Error).message}`, {
+    console.error("[STRIPE_WEBHOOK] Error constructing event:", error);
+    return new NextResponse("Webhook Error", {
       status: 400,
     });
   }


### PR DESCRIPTION
Potential fix for [https://github.com/shiftbloom-studio/open-hallucination-index/security/code-scanning/8](https://github.com/shiftbloom-studio/open-hallucination-index/security/code-scanning/8)

In general, to fix “exception text reinterpreted as HTML” issues, avoid sending raw exception messages (which may include user-controlled data) directly in HTTP responses or HTML. Instead, either:

- Return a generic, non-detailed error message to the client, and
- Log the detailed error server-side for debugging/monitoring purposes, or
- If you truly must send the message back, escape/encode it appropriately for the output context (HTML, JSON, etc.).

For this specific code:

- The vulnerability is at line 22 in `frontend/src/app/api/webhooks/stripe/route.ts`, where the error message is interpolated into the response body.
- The best fix without changing observable behavior in a meaningful way is to:
  - Log the detailed Stripe webhook error to the server console (or monitoring), and
  - Return a generic error message string that does not include any user-controlled content.

Concretely:

- In the `catch (error)` block around `constructEvent`, insert a `console.error` that logs the full error.
- Change `new NextResponse(\`Webhook Error: ${(error as Error).message}\`, { status: 400 })` to `new NextResponse("Webhook Error", { status: 400 })` (or some other static string).

No new imports or helper functions are required; the built-in `console` and `NextResponse` are already in use.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
